### PR TITLE
remove step 3 from migration guide

### DIFF
--- a/platform/manual/migration-v0_16/index.rst
+++ b/platform/manual/migration-v0_16/index.rst
@@ -31,32 +31,3 @@ the following command:
 
 Replace alias with the alias of the cluster that need to be upgraded.
 The cluster will be upgraded to ``v0.16``.
-
-Step 3: (Known issue) Modify permission rules
----------------------------------------------
-
-Until a bug regarding variable names in permission rules with GraphQL Engine
-(`hasura/graphql-engine#317
-<https://github.com/hasura/graphql-engine/issues/317>`_) is fixed, a few extra
-steps are required to get the latest platform version working.
-
-Export graphql engine metadata:
-
-.. code::
-
-   hasura platform:metadata export
-
-This will create a file called ``metadata.yaml`` inside ``migrations``
-directory. Edit this file and replace all occurances of ``REQ_USER_ID`` with
-``X-Hasura-User-Id`` (if any). Also replace all occurances in migration files.
-
-.. code::
-
-   # bash
-   sed -i 's/REQ_USER_ID/X-Hasura-User-Id/' migrations/*.yaml
-
-Apply the edited metadata:
-
-.. code::
-
-   hasura platform:metadata apply


### PR DESCRIPTION
The issue for which step 3 is a workaround has been fixed in platform 16.1