### PR TITLE
typo : Double use words

### DIFF
--- a/platform/manual/data/alter-schema/adding-foreign-key-constraint.rst
+++ b/platform/manual/data/alter-schema/adding-foreign-key-constraint.rst
@@ -5,7 +5,7 @@ If many records will refer to the same data, it is more efficient and less error
 
 In this section, we will show how to add a foreign key constraint over a column. Consider a sample schema with an ``article`` and an ``author`` table. Lets try to add a foreign key constraint over the ``author_id`` column of the ``article`` table.
 
-#. Open the API Console and go to to the Data Tab.
+#. Open the API Console and go to the Data Tab.
 #. Choose the ``article`` table on the left panel.
 #. Click on the ``Modify`` tab.
 #. Click on the column name that you wish to add a foreign key constraint over (in this case, ``author_id``).

--- a/platform/manual/project/directory-structure/conf/gateway.yaml.rst
+++ b/platform/manual/project/directory-structure/conf/gateway.yaml.rst
@@ -7,7 +7,7 @@ Project structure: conf/gateway.yaml
 
    This file is rendered as a template. Refer to :ref:`Conf files templating <conf-templating>` for more details.
 
-Configuration for opening the the API Gateway to the external world can be found in this file. It is usually filled in from cluster metadata, which also contains Kubernetes specific configuration.
+Configuration for opening the API Gateway to the external world can be found in this file. It is usually filled in from cluster metadata, which also contains Kubernetes specific configuration.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Fixing typo double use of "to" and "the"